### PR TITLE
Fix Docker builds and improve Dockerfile (#22)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Docker build environment #
 ############################
 
-FROM node:18.16.1-bookworm-slim AS build
+FROM node:lts-bookworm-slim AS build
 
 # Upgrade all packages and install dependencies
 RUN apt-get update \
@@ -23,7 +23,7 @@ RUN npm i && npm run build
 # Docker final environment #
 ############################
 
-FROM caddy:2.7.4-alpine
+FROM caddy:alpine AS final
 
 EXPOSE 80
 WORKDIR /var/www/html


### PR DESCRIPTION
* Fix Docker builds and improve Dockerfile

* Use latest bookworm-slim image for Node

* Properly name final image

* Use LTS Node version instead of latest